### PR TITLE
Feature/dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,17 +97,12 @@ You can set:
 - The OS timezone inside the container (argument TZ, default is `Europe/Rome`)
 - CVA6-SDK Git repository url (argument GIT_REPO_URL, default is `"https://github.com/openhwgroup/cva6-sdk"`)
 - CVA6-SDK Git commit to checkout (argument GIT_REPO_COMMIT, default is `0f605ac`)
-- Name of the user inside the container (argument CONTAINER_USER, default is `user`)
 
 Consider that image creation will automatically download and build the RISC-V toolchain, which may be a slow process.
 On the other hand, such a choice is convenient: since any software development will require a working RISC-V toolchain it worths build it once for all on image creation.
 To build the SDK docker image from the repository top-level directory type:
 ```
 $ docker build -t cva6-sdk container
-```
-As an example, to build the image creating a user with the same name of your host user type:
-```
-$ docker build -t cva6-sdk --build-arg CONTAINER_USER=$(whoami) container
 ```
 
 #### Run a container instance

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -6,7 +6,6 @@ FROM ubuntu:20.04
 ARG TZ="Europe/Rome"
 ARG GIT_REPO_URL="https://github.com/openhwgroup/cva6-sdk"
 ARG GIT_REPO_COMMIT="0f605ac"
-ARG CONTAINER_USER="user"
 
 # -----------------------------------------------------------------------------
 # Configure timezone.
@@ -50,23 +49,15 @@ RUN apt-get install -y 		\
 	libncurses-dev
 
 # -----------------------------------------------------------------------------
-# Create a new user.
-# -----------------------------------------------------------------------------
-RUN useradd -ms /bin/bash $CONTAINER_USER
-RUN passwd -d $CONTAINER_USER
-WORKDIR /home/$CONTAINER_USER
-USER $CONTAINER_USER
-
-# -----------------------------------------------------------------------------
 # Download cva6-sdk and build the RISC-V toolchain.
 # -----------------------------------------------------------------------------
-ENV RISCV="/home/$CONTAINER_USER/.local/riscv"
+ENV RISCV="/root/riscv"
 ENV PATH="$PATH:$RISCV/bin"
 
-RUN git clone $GIT_REPO_URL /home/$CONTAINER_USER/cva6-sdk
-WORKDIR /home/$CONTAINER_USER/cva6-sdk
+RUN git clone $GIT_REPO_URL /root/cva6-sdk
+WORKDIR /root/cva6-sdk
 RUN git checkout $GIT_REPO_COMMIT
 RUN git submodule update --init --recursive
 RUN make all
-WORKDIR /home/$CONTAINER_USER
+WORKDIR /root
 


### PR DESCRIPTION
Add features to the Dockerfile provided to make the resulting image more suitable for CVA6 software development.
New Dockerfile features:
- Move base image from `ubuntu:18.04` to `ubuntu:20.04`.
- Install `libncurses-dev` to allow Buildroot and Linux Kernel configuration from within the container.
- Add a non-root user inside the container.
- Download and build the RISC-V toolchain on docker image construction.
- Update the README.md accordingly with the performed changes.