### PR TITLE
Fix: add missing install-dir prerequisite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ rootfs/tetris: $(CC)
 	cd ./vitetris/ && make clean && ./configure CC=$(CC) && make
 	cp ./vitetris/tetris $@
 
-$(RISCV)/vmlinux: $(buildroot_defconfig) $(linux_defconfig) $(busybox_defconfig) $(CC) rootfs/cachetest.elf rootfs/tetris
+$(RISCV)/vmlinux: install-dir $(buildroot_defconfig) $(linux_defconfig) $(busybox_defconfig) $(CC) rootfs/cachetest.elf rootfs/tetris
 	mkdir -p build
 	make -C buildroot
 	cp buildroot/output/images/vmlinux build/vmlinux


### PR DESCRIPTION
Add missing `install-dir` prerequisite to the `vmlinux` target, so that copying of `vmlinux`, `bbl`, etc. succeeds at the end of build.