### PR TITLE
Correction of flash SD-CARD recipe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,13 +129,17 @@ $(RISCV)/spike_fw_payload.elf: $(RISCV)/Image
 FWPAYLOAD_SECTORSTART := 2048
 FWPAYLOAD_SECTORSIZE = $(shell ls -l --block-size=512 $(RISCV)/fw_payload.bin | cut -d " " -f5 )
 FWPAYLOAD_SECTOREND = $(shell echo $(FWPAYLOAD_SECTORSTART)+$(FWPAYLOAD_SECTORSIZE) | bc)
+SDDEVICE_PART1 = $(shell lsblk $(SDDEVICE) -no PATH | head -2 | tail -1)
+SDDEVICE_PART2 = $(shell lsblk $(SDDEVICE) -no PATH | head -3 | tail -1)
 # Always flash uImage at 512M, easier for u-boot boot command
 UIMAGE_SECTORSTART := 512M
-flash-sdcard:
+flash-sdcard: format-sd
+	dd if=$(RISCV)/fw_payload.bin of=$(SDDEVICE_PART1) status=progress oflag=sync bs=1M
+	dd if=$(RISCV)/uImage         of=$(SDDEVICE_PART2) status=progress oflag=sync bs=1M
+
+format-sd: $(SDDEVICE)
 	@test -n "$(SDDEVICE)" || (echo 'SDDEVICE must be set, Ex: make flash-sdcard SDDEVICE=/dev/sdc' && exit 1)
 	sgdisk --clear -g --new=1:$(FWPAYLOAD_SECTORSTART):$(FWPAYLOAD_SECTOREND) --new=2:$(UIMAGE_SECTORSTART):0 --typecode=1:3000 --typecode=2:8300 $(SDDEVICE)
-	dd if=$(RISCV)/fw_payload.bin of=$(SDDEVICE)1 status=progress oflag=sync bs=1M
-	dd if=$(RISCV)/uImage         of=$(SDDEVICE)2 status=progress oflag=sync bs=1M
 
 # specific recipes
 gcc: $(CC)

--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,7 @@ FWPAYLOAD_SECTOREND = $(shell echo $(FWPAYLOAD_SECTORSTART)+$(FWPAYLOAD_SECTORSI
 UIMAGE_SECTORSTART := 512M
 flash-sdcard:
 	@test -n "$(SDDEVICE)" || (echo 'SDDEVICE must be set, Ex: make flash-sdcard SDDEVICE=/dev/sdc' && exit 1)
-	sgdisk --clear --new=1:$(FWPAYLOAD_SECTORSTART):$(FWPAYLOAD_SECTOREND) --new=2:$(UIMAGE_SECTORSTART):0 --typecode=1:3000 --typecode=2:8300 $(SDDEVICE)
+	sgdisk --clear -g --new=1:$(FWPAYLOAD_SECTORSTART):$(FWPAYLOAD_SECTOREND) --new=2:$(UIMAGE_SECTORSTART):0 --typecode=1:3000 --typecode=2:8300 $(SDDEVICE)
 	dd if=$(RISCV)/fw_payload.bin of=$(SDDEVICE)1 status=progress oflag=sync bs=1M
 	dd if=$(RISCV)/uImage         of=$(SDDEVICE)2 status=progress oflag=sync bs=1M
 


### PR DESCRIPTION
- We observed errors when the SDCARD was previously formated in MBR. The -g flag is converting the partition table to GPT.

- Also, error happens whith internal SDCARD reader. Those type of device enumerates the partitions differently : 
```
/dev/mmcblk1
/dev/mmcblk1p1
/dev/mmcblk1p2
```
lsblk call correct this error.