### PR TITLE
Fix u-boot repo path

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -14,7 +14,7 @@
 	url = https://github.com/pulp-platform/vitetris.git
 [submodule "u-boot"]
 	path = u-boot
-	url = https://github.com/openhwgroup/u-boot/
+	url = https://github.com/openhwgroup/u-boot
 [submodule "opensbi"]
 	path = opensbi
 	url = https://github.com/riscv/opensbi.git


### PR DESCRIPTION
Otherwise, got a `not found` error:
```bash
$ git clone https://github.com/openhwgroup/u-boot/
Cloning into 'u-boot'...
ERROR: Repository not found.
fatal: Could not read from remote repository.
```