### PR TITLE
Update README.md with Genesys 2 disclaimer

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Included tools:
 * [u-boot](https://github.com/openhwgroup/u-boot/)
 * [opensbi](https://github.com/riscv/opensbi/), the open-source reference implementation of the RISC-V Supervisor Binary Interface (SBI)
 
+As of now, only the **Digilent Genesys 2 is supported**. You will need to adapt the SDK to different boards. To add more board support in this repository, you can volunteer to create a new project at the OpenHW Group.
+
 ## Quickstart
 
 Requirements Ubuntu:


### PR DESCRIPTION
As of now, only the Genesys 2 board is described in the SDK. This disclaimer is added to better inform the users.