### PR TITLE
Build updates - make uboot image known size and allow file output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,13 +133,14 @@ SDDEVICE_PART1 = $(shell lsblk $(SDDEVICE) -no PATH | head -2 | tail -1)
 SDDEVICE_PART2 = $(shell lsblk $(SDDEVICE) -no PATH | head -3 | tail -1)
 # Always flash uImage at 512M, easier for u-boot boot command
 UIMAGE_SECTORSTART := 512M
+UIMAGE_SECTOREND := 544M
 flash-sdcard: format-sd
 	dd if=$(RISCV)/fw_payload.bin of=$(SDDEVICE_PART1) status=progress oflag=sync bs=1M
 	dd if=$(RISCV)/uImage         of=$(SDDEVICE_PART2) status=progress oflag=sync bs=1M
 
 format-sd: $(SDDEVICE)
 	@test -n "$(SDDEVICE)" || (echo 'SDDEVICE must be set, Ex: make flash-sdcard SDDEVICE=/dev/sdc' && exit 1)
-	sgdisk --clear -g --new=1:$(FWPAYLOAD_SECTORSTART):$(FWPAYLOAD_SECTOREND) --new=2:$(UIMAGE_SECTORSTART):0 --typecode=1:3000 --typecode=2:8300 $(SDDEVICE)
+	sgdisk --clear -g --new=1:$(FWPAYLOAD_SECTORSTART):$(FWPAYLOAD_SECTOREND) --new=2:$(UIMAGE_SECTORSTART):${UIMAGE_SECTOREND} --typecode=1:3000 --typecode=2:8300 $(SDDEVICE)
 
 # specific recipes
 gcc: $(CC)

--- a/Makefile
+++ b/Makefile
@@ -142,6 +142,16 @@ format-sd: $(SDDEVICE)
 	@test -n "$(SDDEVICE)" || (echo 'SDDEVICE must be set, Ex: make flash-sdcard SDDEVICE=/dev/sdc' && exit 1)
 	sgdisk --clear -g --new=1:$(FWPAYLOAD_SECTORSTART):$(FWPAYLOAD_SECTOREND) --new=2:$(UIMAGE_SECTORSTART):${UIMAGE_SECTOREND} --typecode=1:3000 --typecode=2:8300 $(SDDEVICE)
 
+# flash-file and format-file are basically the same as the sdcard ones but aum to use a file
+
+flash-file: format-file
+	dd if=$(RISCV)/fw_payload.bin of=$(IMGFILE) seek=${FWPAYLOAD_SECTORSTART} status=progress conv=notrunc bs=512
+	dd if=$(RISCV)/uImage         of=$(IMGFILE) seek=$(UIMAGE_SECTORSTART) status=progress conv=notrunc bs=1
+
+format-file:
+	@test -n "$(IMGFILE)" || (echo 'IMGFILE must be set, Ex: make format-file IMGFILE=output.img' && exit 1)
+	sgdisk --clear -g --new=1:$(FWPAYLOAD_SECTORSTART):$(FWPAYLOAD_SECTOREND) --new=2:$(UIMAGE_SECTORSTART):${UIMAGE_SECTOREND} --typecode=1:3000 --typecode=2:8300 $(IMGFILE)
+
 # specific recipes
 gcc: $(CC)
 vmlinux: $(RISCV)/vmlinux


### PR DESCRIPTION
Add the ability to build to an file for use with qemu and possibly other testing.
Set the uboot partition size to make it easier to then add a user partition after it