### PR TITLE
Buildroot repository updated to official URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,7 +8,7 @@
 	branch = master
 [submodule "buildroot"]
 	path = buildroot
-	url = git://git.buildroot.net/buildroot
+	url = https://gitlab.com/buildroot.org/buildroot.git
 [submodule "vitetris"]
 	path = vitetris
 	url = https://github.com/pulp-platform/vitetris.git


### PR DESCRIPTION
The official buildroot repository is: https://gitlab.com/buildroot.org/buildroot.git as described in https://lists.buildroot.org/pipermail/buildroot/2023-September/361782.html and in the official website.

Also, the old git://git.buildroot.net/buildroot is not working (anymore?). 
